### PR TITLE
Add helper to check biometrics support

### DIFF
--- a/Sources/KeychainLibrary.swift
+++ b/Sources/KeychainLibrary.swift
@@ -131,3 +131,11 @@ func _getPassword(context: LAContext, service: String, completion: @escaping (Re
         completion(.failure(.cannotRetrieve("Failed to retrieve data from keychain")))
     }
 }
+
+@_cdecl("isBiometricsSupported")
+public func isBiometricsSupported() -> Bool {
+        let context = LAContext()
+        return context.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: nil)
+    
+    return false
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,3 +50,9 @@ export const getPassword = async (params: GetPasswordParams): Promise<string> =>
 
     return secretResult;
 };
+
+export const isBiometricsSupported = (): boolean => {
+    const biometricsSupported = lib.func('isBiometricsSupported', 'bool', []);
+
+    return biometricsSupported() as boolean;
+};

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -1,5 +1,10 @@
 import * as keychain from '../src';
 
+if (!keychain.isBiometricsSupported()) {
+    console.error(`Keychain is not supported on this platform`);
+    process.exit(1);
+}
+
 console.log(`Adding to keychain...`);
 
 const isSuccess2 = keychain.setPassword({


### PR DESCRIPTION
Usage: 

```ts
import * as keychain from '../src';

if (!keychain.isBiometricsSupported()) {
    console.error(`Keychain is not supported on this platform`);
    process.exit(1);
}
```